### PR TITLE
Update channel ordering to include Last_Update

### DIFF
--- a/resources/lib/service/guide.py
+++ b/resources/lib/service/guide.py
@@ -82,7 +82,7 @@ class Guide(object):
         query = "SELECT DISTINCT Channels.Guid, Channels.name, Channels.thumbnail, Channels.qvt_url, Channels.genre " \
                 "FROM Channels " \
                 "INNER JOIN Guide on Channels.GUID = Guide.Channel_GUID " \
-                "WHERE Channels.Name NOT LIKE '%Sling%' AND Channels.Hidden = 0 ORDER BY Channels.Name asc"
+                "WHERE Channels.Name NOT LIKE '%Sling%' AND Channels.Hidden = 0 ORDER BY Channels.Name asc, Channels.Last_Update asc"
         try:
             cursor = self.DB.cursor()
             cursor.execute(query)


### PR DESCRIPTION
This fixes an issue for users with both Sling Orange and Sling Blue channel line-ups. If the channel is present in both Orange and Blue, this will use the Orange URL.